### PR TITLE
Update quick-start-protein-folding.ipynb

### DIFF
--- a/notebooks/quick-start-protein-folding.ipynb
+++ b/notebooks/quick-start-protein-folding.ipynb
@@ -488,7 +488,7 @@
     "target.download_predictions(local_path=\"data\", job=last_job_name)\n",
     "\n",
     "print(f\"Displaying predicted structure for job {last_job_name}\")\n",
-    "pdb = f\"data/{target_id}/predictions/{last_job_name}/{target_id}.pdb\"\n",
+    "pdb = f\"data/{target_id}/predictions/{last_job_name}/prediction.pdb\"\n",
     "utils.plot_banded_pdb(pdb)\n",
     "utils.plot_metrics(pdb)"
    ]


### PR DESCRIPTION
Output for the ESMFold code found at infrastructure/docker/esmfold/esm/scripts/esmfold_inference.py on line 199 is a file called prediction.pdb.  The Quick-Start Notebook is looking for pdb = f"data/{target_id}/predictions/{last_job_name}/{target_id}.pdb" for the plot data which is not a valid file.